### PR TITLE
soupsieve 2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.3.2.post1" %}
+{% set version = "2.4" %}
 
 package:
   name: soupsieve
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/soupsieve/soupsieve-{{ version }}.tar.gz
-  sha256: fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
+  sha256: e28dba9ca6c7c00173e34e4ba57448f0688bb681b7c5e8bf4971daafc093d69a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ build:
 
 requirements:
   host:
-    - hatchling >=0.21.1
+    - hatchling 1.12.2
     - pip
     - python
+    - wheel
   run:
     - python
 
@@ -36,7 +37,6 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
-  license_url: https://github.com/facelessuser/soupsieve/blob/{{ version }}/LICENSE.md
   summary: A modern CSS selector implementation for BeautifulSoup
   description: |
       Soup Sieve is a CSS selector library designed to be used with Beautiful Soup 4.
@@ -45,7 +45,6 @@ about:
       through the latest CSS level 4 drafts and beyond (though some are not yet implemented).
   dev_url: https://github.com/facelessuser/soupsieve
   doc_url: https://facelessuser.github.io/soupsieve/
-  doc_source_url: https://github.com/facelessuser/soupsieve/blob/{{ version }}/LICENSE.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Jira ticket:** [PKG-1135](https://anaconda.atlassian.net/browse/PKG-1135)

**The upstream data:**
Github releases:  https://github.com/facelessuser/soupsieve/releases
[Diff between the latest and previous upstream releases](https://github.com/facelessuser/soupsieve/compare/2.3.2.post1...2.4)
Requirements:
 * pyproject.toml:  https://github.com/facelessuser/soupsieve/blob/2.4/pyproject.toml

**_Actions:_**

1. Add wheel
2. Update pinnings
3. Remove license_url
4. Remove doc_source_url

**_Notes:_**
 * beautifulsoup4 depends on it https://github.com/AnacondaRecipes/beautifulsoup4-feedstock/pull/6

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: miniconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.4
 * Release on PyPi:
    * version: 2.4
    * date: 2023-02-14T16:32:50
* [PyPi history](https://pypi.org/project/soupsieve/#history)
 * Popularity: 
    * 3 months downloads: 2169398.0
    * All time:  10706913 downloads -  soupsieve  2.3.2.post1  A modern CSS selector implementation for BeautifulSoup  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
5. - [ ] Verify that the `build_number` is correct
6. - [ ] Verify if the package needs `setuptools`
    
7. - [ ] Verify if the package needs `wheel`
    
8. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.md is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/soupsieve-feedstock/recipe/meta.yaml
Dependencies: ['hatchling >=0.21.1', 'pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/soupsieve-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/soupsieve-feedstock/tree/2.4)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/soupsieve)
* [Diff between upstream and feature branch](https://github.com/conda-forge/soupsieve-feedstock/compare/main...AnacondaRecipes:2.4)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/soupsieve-feedstock/compare/master...AnacondaRecipes:2.4)
* [The last merged PRs](https://github.com/AnacondaRecipes/soupsieve-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>


**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.4 git@github.com:AnacondaRecipes/soupsieve-feedstock.git
```


[PKG-1135]: https://anaconda.atlassian.net/browse/PKG-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ